### PR TITLE
Allow users to change the drilldown behaviour in treemap

### DIFF
--- a/widgets/treemap/main.js
+++ b/widgets/treemap/main.js
@@ -32,6 +32,9 @@ OpenSpending.Treemap = function (elem, context, state) {
     tooltipMessage: function(widget, node) {
       var percentualValue = (node.data.value * 100)/widget.total;
       return node.name + " (" + OpenSpending.Utils.formatAmountWithCommas(percentualValue, 2) + "%)";
+    },
+    drilldown: function(node) {
+      self.drilldown(node);
     }
   }, context);
   self.state = state;
@@ -198,7 +201,7 @@ OpenSpending.Treemap = function (elem, context, state) {
           enable: true,
           onClick: function(node) {
             if(node) {
-              self.drilldown(node);
+              self.context.drilldown(node);
             }
           },
           onRightClick: function() {


### PR DESCRIPTION
Creates a context variable _drilldown_ that can be overwritten. This allows for breadcrumb generation and dynamic single page representation of each stage of the treemap like the one done on [openbudgetoakland](http://openbudgetoakland.org/mayor_13-15_proposed.html). Fixes #17 
