### PR TITLE
[#25] Check that the browser supports Canvas explicitly, instead of testing for IE

### DIFF
--- a/widgets/treemap/main.js
+++ b/widgets/treemap/main.js
@@ -10,7 +10,7 @@ OpenSpending.Treemap = function (elem, context, state) {
                  OpenSpending.scriptRoot + "/widgets/treemap/css/treemap.css"
                  ];
 
-  if ($.browser.msie) {
+  if (!window.HTMLCanvasElement) {
     resources.push(OpenSpending.scriptRoot + "/widgets/treemap/js/excanvas.js");
   }
 


### PR DESCRIPTION
What motivated me is that $.browser was deprecated in JQuery 1.3, and removed
in 1.9. Thsi new test is faster and better.

Check
http://stackoverflow.com/questions/2745432/best-way-to-detect-that-html5-canvas-is-not-supported
for more info.
