### PR TITLE
Removed [from, to] from treemap defaults. Because $.extend doesn't overw...

### DIFF
--- a/src/visualisations/jquery.treemap.js
+++ b/src/visualisations/jquery.treemap.js
@@ -254,7 +254,7 @@
 	    site: 'http://openspending.org',
 	    dataset: undefined,
 	    // We put from and to as default values because they are common
-	    drilldowns: ['from', 'to'],
+	    drilldowns: [],
 	    year: undefined,
 	    cuts: {}
 	},


### PR DESCRIPTION
"Removed [from, to] from treemap defaults. Because $.extend doesn't overwrite all the defaults when there are less than 2 drilldowns in the options. So in case of less than 2 drilldowns 'to' was added to the end of the array, even in cases where the dataset doesn't have 'to' as a drilldown. Thus causing errors. This solves that.
