### PR TITLE
Use common response key instead of UK specific ones

### DIFF
--- a/app/dailybread/js/dailybread.js
+++ b/app/dailybread/js/dailybread.js
@@ -130,7 +130,7 @@ OpenSpending.DailyBread = function (elem, opts) {
       }, self.opts.taxman));
 
     rq.then(function (data) {
-      self.taxVal = data.calculation.directs.total + data.calculation.indirects.total;
+      self.taxVal = data.calculation.total;
     })
 
     return rq;


### PR DESCRIPTION
Adding `directs.total` and `indirects.total` is too tied to the UK. I think the TaxMan for gb should return the sum of them in `data.calculation.total` if you want to get the sum of them. What do you think?
