### PR TITLE
parseQueryString() is using deprecated unescape()

### DIFF
--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -63,7 +63,7 @@ function parseQueryString() {
   var q = arguments.length > 0 ? arguments[0] : window.location.search.substring(1);
   var urlParams = [],
     e, d = function (s) {
-      return unescape(s.replace(/\+/g, " "));
+      return decodeURIComponent(s.replace(/\+/g, " "));
     },
     r = /([^&=]+)=?([^&]*)/g;
 

--- a/src/utils/openspending.common.js
+++ b/src/utils/openspending.common.js
@@ -30,8 +30,8 @@ OpenSpending.Common.parseQueryString = function(querystring) {
 
     // Tiny cleanup function
     var clean = function (param) {
-	// We replace all + with whitespace and return in unescaped
-	return unescape(param.replace(/\+/g, " "));
+        // We replace all + with whitespace and return in unescaped
+        return decodeURIComponent(param.replace(/\+/g, " "));
     };
 
     // Parameter regular expression (even though they're not cool with urls


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features

> The escape and unescape functions are deprecated. Use encodeURI, encodeURIComponent, decodeURI or decodeURIComponent to encode and decode escape sequences for special characters.

The problem I had with it is was with accented characters:

```
> str = encodeURIComponent("Yaoundé 6")
"Yaound%C3%A9%206"
> unescape(str)
"YaoundÃ© 6"
> decodeURIComponent(str)
"Yaoundé 6"
```

This won't happen if we've used `escape(str)` instead of `encodeURIComponent()`, but the encoded string that comes from the `window.location`, for example, uses the codification as `encodeURIComponent()`.

There's a good comparison about these methods in http://xkr.us/articles/javascript/encode-compare/
